### PR TITLE
Fix_チャットルームでリロード時ユーザーがDBに残り続けるバグの修正

### DIFF
--- a/src/components/molucules/PrimaryInput.tsx
+++ b/src/components/molucules/PrimaryInput.tsx
@@ -13,10 +13,7 @@ type Props = {
 
 export const PrimaryInput: FC<Props> = memo((props) => {
   const { onClickButton, onChange, buttonLabel, value } = props;
-  const onBlur = useCallback(
-    () => isMobile && window.scrollTo(0, -100),
-    [isMobile]
-  );
+  const onBlur = useCallback(() => isMobile && window.scrollTo(0, -100), []);
 
   return (
     <Stack direction="row" align="center" justify="center" w="100%">

--- a/src/components/organisms/layout/Header.tsx
+++ b/src/components/organisms/layout/Header.tsx
@@ -10,7 +10,7 @@ export const Header: FC<Props> = memo((props) => {
   const { children } = props;
   const navigate = useNavigate();
 
-  const onClickTop = useCallback(() => navigate("/"), []);
+  const onClickTop = useCallback(() => navigate("/"), [navigate]);
 
   return (
     <Flex

--- a/src/components/pages/ChatRoom.tsx
+++ b/src/components/pages/ChatRoom.tsx
@@ -28,10 +28,7 @@ export const ChatRoom: FC = memo(() => {
   const { deleteUser } = useDeleteUser();
   const roomName = useRecoilValue(roomState);
 
-  useEffect(
-    () => (isMobile ? window.scrollTo(0, -100) : undefined),
-    [isMobile]
-  );
+  useEffect(() => (isMobile ? window.scrollTo(0, -100) : undefined), []);
 
   useEffect(() => {
     window.addEventListener("beforeunload", () => deleteUser());
@@ -52,7 +49,7 @@ export const ChatRoom: FC = memo(() => {
   const onClickPost = useCallback(() => {
     updateMsg();
     setMessage("");
-  }, [message]);
+  }, [message, updateMsg]);
 
   const onChangePost = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => setMessage(e.target.value),

--- a/src/components/pages/Top.tsx
+++ b/src/components/pages/Top.tsx
@@ -30,13 +30,13 @@ export const Top: FC = memo(() => {
       deleteUser();
       setAuthInfo({ isAuth: false });
     }
-  }, []);
+  }, [deleteUser, setAuthInfo]);
 
   useEffect(() => {
     selectRoom();
-  }, [roomName]);
+  }, [roomName, selectRoom]);
 
-  const onClickChatRoom = useCallback(() => addUserToDB(), [userName]);
+  const onClickChatRoom = useCallback(() => addUserToDB(), [addUserToDB]);
 
   const onChangeName = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => setUserName(e.target.value),

--- a/src/components/templates/HeaderOnlyLayout.tsx
+++ b/src/components/templates/HeaderOnlyLayout.tsx
@@ -24,7 +24,7 @@ export const HeaderOnlyLayout: FC<Props> = memo((props) => {
     setUserInfo({ isAuth: false });
     navigate("/");
     showToastMsg({ title: "チャットルームを退室しました", status: "info" });
-  }, []);
+  }, [deleteUser, navigate, setUserInfo, showToastMsg]);
 
   return (
     <>

--- a/src/hooks/useAddUserToDB.ts
+++ b/src/hooks/useAddUserToDB.ts
@@ -20,7 +20,7 @@ export const useAddUserToDB = (userName: string) => {
 
   useEffect(() => {
     selectRoom();
-  }, []);
+  }, [selectRoom]);
 
   const addUserToDB = async () => {
     if (userName) {

--- a/src/hooks/useDeleteUser.ts
+++ b/src/hooks/useDeleteUser.ts
@@ -12,7 +12,7 @@ export const useDeleteUser = () => {
 
   const deleteUser = useCallback(async () => {
     await deleteDoc(doc(db, roomName, userInfo.uuid));
-  }, [userInfo.uuid]);
+  }, [userInfo.uuid, roomName]);
 
   return { deleteUser };
 };

--- a/src/hooks/useSelectRoom.ts
+++ b/src/hooks/useSelectRoom.ts
@@ -17,7 +17,7 @@ export const useSelectRoom = () => {
       i++;
     }
     setRoomName(`room${i}`);
-  }, []);
+  }, [setRoomName]);
 
   return { selectRoom };
 };


### PR DESCRIPTION
### 概要
チャットルームでリロードした時にDBにユーザーが残ってしまい、チャットルームに存在しないユーザーが
残り続けてしまうバグを修正しました。

window.addEventListenerでbeforeunload時にユーザーをDBから削除するように実装しました。

### コメント
動作確認時にnpm run build コマンドでbuildしたところ、Warningが複数出ましたのでこちらのブランチで修正しております。
ご確認お願いたします。
